### PR TITLE
Breadcrumbs Filters

### DIFF
--- a/src/AspNetCore/Breadcrumbs/README.md
+++ b/src/AspNetCore/Breadcrumbs/README.md
@@ -143,6 +143,10 @@ public void ConfigureServices( IServiceCollection services )
 }
 ```
 
+#### Breadcrumbs Filters
+
+An `IBreadcrumbsFilter` contract and an `abstract` base class `BreadcrumbsFilter` are provided, which can be used to customize `BreadcrumbItem`s prior to the `XperienceBreadcrumbs` ViewComponent invoking it's View. See the [`ExcludeLastBreadcrumbPathFilter`](src/Filters/ExcludeLastBreadcrumbPathFilter.cs) for an example.
+
 ## FAQ
 
 - _Will this `ViewComponent` work if I'm not using Page Routing?_

--- a/src/AspNetCore/Breadcrumbs/src/Abstractions/BreadcrumbsFilter.cs
+++ b/src/AspNetCore/Breadcrumbs/src/Abstractions/BreadcrumbsFilter.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace BizStream.Kentico.Xperience.AspNetCore.Components.Breadcrumbs.Abstractions
+{
+
+    /// <summary> Abstract implementation of <see cref="IBreadcrumbsFilter"/>. </summary>
+    public abstract class BreadcrumbsFilter : IBreadcrumbsFilter
+    {
+        #region Properties
+
+        /// <inheritdoc/>
+        public virtual int Order => 0;
+        #endregion
+
+        public abstract Task<IEnumerable<BreadcrumbItem>> OnFilterBreadcrumbsAsync( HttpContext context, IEnumerable<BreadcrumbItem> breadcrumbs );
+
+    }
+}

--- a/src/AspNetCore/Breadcrumbs/src/Abstractions/IBreadcrumbsFilter.cs
+++ b/src/AspNetCore/Breadcrumbs/src/Abstractions/IBreadcrumbsFilter.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace BizStream.Kentico.Xperience.AspNetCore.Components.Breadcrumbs.Abstractions
+{
+
+    /// <summary> Describes a service that may be used by the <see cref="XperienceBreadcrumbs"/> ViewComponent to modify retrieved <see cref="BreadcrumbItem"/>s. </summary>
+    public interface IBreadcrumbsFilter
+    {
+        #region Properties
+
+        /// <summary> Order of filter execution. Filters with a greater <see cref="Order"/> are executed first. </summary>
+        int Order { get; }
+        #endregion
+
+        /// <summary> Filter the given <paramref name="breadcrumbs"/> for the given <paramref name="context"/>. </summary>
+        /// <param name="context"> The current <see cref="HttpContext"/>. </param>
+        /// <param name="breadcrumbs"> The <see cref="BreadcrumbItem"/>s to modify. </param>
+        /// <returns> The modified <paramref name="breadcrumbs"/>. </returns>
+        Task<IEnumerable<BreadcrumbItem>> OnFilterBreadcrumbsAsync( HttpContext context, IEnumerable<BreadcrumbItem> breadcrumbs );
+
+    }
+
+}

--- a/src/AspNetCore/Breadcrumbs/src/BizStream.Kentico.Xperience.AspNetCore.Components.Breadcrumbs.csproj
+++ b/src/AspNetCore/Breadcrumbs/src/BizStream.Kentico.Xperience.AspNetCore.Components.Breadcrumbs.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <Description>This package provides a Mvc ViewComponent implementation, and accompanying services, for rendering Breadcrumbs based on Content Tree Routing.</Description>
-        <VersionPrefix>2.0.1</VersionPrefix>
+        <VersionPrefix>2.1.0</VersionPrefix>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/AspNetCore/Breadcrumbs/src/Filters/EmptyLastBreadcrumbPathFilter.cs
+++ b/src/AspNetCore/Breadcrumbs/src/Filters/EmptyLastBreadcrumbPathFilter.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using BizStream.Kentico.Xperience.AspNetCore.Components.Breadcrumbs.Abstractions;
@@ -8,7 +9,7 @@ namespace BizStream.Kentico.Xperience.AspNetCore.Components.Breadcrumbs.Filters
 {
 
     /// <summary> Ensures the last breadcrumb's <see cref="BreadcrumbItem.Path"/> is empty. </summary>
-    public class ExcludeLastBreadcrumbPathFilter : BreadcrumbsFilter
+    public class EmptyLastBreadcrumbPathFilter : BreadcrumbsFilter
     {
         #region Properties
 

--- a/src/AspNetCore/Breadcrumbs/src/Filters/ExcludeLastBreadcrumbPathFilter.cs
+++ b/src/AspNetCore/Breadcrumbs/src/Filters/ExcludeLastBreadcrumbPathFilter.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using BizStream.Kentico.Xperience.AspNetCore.Components.Breadcrumbs.Abstractions;
+using Microsoft.AspNetCore.Http;
+
+namespace BizStream.Kentico.Xperience.AspNetCore.Components.Breadcrumbs.Filters
+{
+
+    /// <summary> Ensures the last breadcrumb's <see cref="BreadcrumbItem.Path"/> is empty. </summary>
+    public class ExcludeLastBreadcrumbPathFilter : BreadcrumbsFilter
+    {
+        #region Properties
+
+        /// <inheritdoc/>
+        public override int Order => -1;
+        #endregion
+
+        /// <inheritdoc/>
+        public override Task<IEnumerable<BreadcrumbItem>> OnFilterBreadcrumbsAsync( HttpContext context, IEnumerable<BreadcrumbItem> breadcrumbs )
+        {
+            var crumbs = breadcrumbs?.ToList() ?? new();
+            if( crumbs.Any() )
+            {
+                crumbs[ ^1 ].Path = PathString.Empty;
+            }
+
+            return Task.FromResult( crumbs.AsEnumerable() );
+        }
+
+    }
+
+}

--- a/src/AspNetCore/Breadcrumbs/src/IServiceCollectionExtensions.cs
+++ b/src/AspNetCore/Breadcrumbs/src/IServiceCollectionExtensions.cs
@@ -22,7 +22,7 @@ namespace BizStream.Kentico.Xperience.AspNetCore.Components.Breadcrumbs
             services.AddOptions<BreadcrumbRetrievalOptions>();
             services.AddTransient<IBreadcrumbsRetriever, BreadcrumbsRetriever>();
 
-            services.AddScoped<IBreadcrumbsFilter, ExcludeLastBreadcrumbPathFilter>();
+            services.AddScoped<IBreadcrumbsFilter, EmptyLastBreadcrumbPathFilter>();
 
             return services;
         }

--- a/src/AspNetCore/Breadcrumbs/src/IServiceCollectionExtensions.cs
+++ b/src/AspNetCore/Breadcrumbs/src/IServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using BizStream.Kentico.Xperience.AspNetCore.Components.Breadcrumbs.Abstractions;
+using BizStream.Kentico.Xperience.AspNetCore.Components.Breadcrumbs.Filters;
 using BizStream.Kentico.Xperience.AspNetCore.Components.Breadcrumbs.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -20,6 +21,9 @@ namespace BizStream.Kentico.Xperience.AspNetCore.Components.Breadcrumbs
 
             services.AddOptions<BreadcrumbRetrievalOptions>();
             services.AddTransient<IBreadcrumbsRetriever, BreadcrumbsRetriever>();
+
+            services.AddScoped<IBreadcrumbsFilter, ExcludeLastBreadcrumbPathFilter>();
+
             return services;
         }
 

--- a/src/AspNetCore/Breadcrumbs/test/EmptyLastBreadcrumbPathFilterTests.cs
+++ b/src/AspNetCore/Breadcrumbs/test/EmptyLastBreadcrumbPathFilterTests.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using BizStream.Kentico.Xperience.AspNetCore.Components.Breadcrumbs.Abstractions;
+using BizStream.Kentico.Xperience.AspNetCore.Components.Breadcrumbs.Filters;
+using Microsoft.AspNetCore.Http;
+using NUnit.Framework;
+
+namespace BizStream.Kentico.Xperience.AspNetCore.Components.Breadcrumbs.Tests
+{
+
+    [TestFixture( Category = "Unit" )]
+    [TestOf( typeof( EmptyLastBreadcrumbPathFilter ) )]
+    public class EmptyLastBreadcrumbPathFilterTests
+    {
+
+        [Test]
+        public void Filter_ShouldNotThrowOnNullOrEmptyBreadcrumbs( )
+        {
+            var filter = new EmptyLastBreadcrumbPathFilter();
+
+            Assert.DoesNotThrowAsync(
+                async ( ) => await filter.OnFilterBreadcrumbsAsync( new DefaultHttpContext(), null )
+            );
+
+            Assert.DoesNotThrowAsync(
+              async ( ) => await filter.OnFilterBreadcrumbsAsync( new DefaultHttpContext(), Enumerable.Empty<BreadcrumbItem>() )
+            );
+        }
+
+        [Test]
+        public async Task Filter_ShouldEmptyLastBreadcrumbItemsPath( )
+        {
+            var breadcrumbs = new List<BreadcrumbItem>
+            {
+                new BreadcrumbItem { Label = "Test", Path = "/test" }
+            };
+
+            var filter = new EmptyLastBreadcrumbPathFilter();
+            var crumbs = ( await filter.OnFilterBreadcrumbsAsync( new DefaultHttpContext(), breadcrumbs ) )
+                .ToList();
+
+            Assert.AreEqual( PathString.Empty, crumbs[ ^1 ].Path );
+        }
+
+    }
+}

--- a/src/AspNetCore/Components/src/BizStream.Kentico.Xperience.AspNetCore.Components.csproj
+++ b/src/AspNetCore/Components/src/BizStream.Kentico.Xperience.AspNetCore.Components.csproj
@@ -4,7 +4,7 @@
         <AutoIncludeReadMe>false</AutoIncludeReadMe>
         <Description>A collection of ASP.NET Core Mvc ViewComponents that integrate with Xperience CMS.</Description>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <VersionPrefix>2.0.1</VersionPrefix>
+        <VersionPrefix>2.1.0</VersionPrefix>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This PR contains the addition of the `IBreadcrumbsFilter` contract, which can be used to modify `BreadcrumbItem`s prior to the `XperienceBreadcrumbs` ViewComponent invoking its View.

Addresses Issue #4.